### PR TITLE
Bump winrm deps

### DIFF
--- a/poise-boiler.gemspec
+++ b/poise-boiler.gemspec
@@ -65,8 +65,8 @@ Gem::Specification.new do |spec|
 
   # Windows integration gems
   spec.add_dependency 'kitchen-ec2', '~> 1.0'
-  spec.add_dependency 'winrm', '~> 1.6'
-  spec.add_dependency 'winrm-fs', '~> 0.4'
+  spec.add_dependency 'winrm', '~> 2.0'
+  spec.add_dependency 'winrm-fs', '~> 1.0'
 
   # Travis gems
   spec.add_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
We are about to update all chef/chef-dk deps to use winrm 2.0 gems. This should prevent chef external test gem conflicts and ensure users of this gem get the updated gems.
