### PR TITLE
bump foodcritic

### DIFF
--- a/poise-boiler.gemspec
+++ b/poise-boiler.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'chefspec', '~> 5.0'
   spec.add_dependency 'fuubar', '~> 2.0'
   spec.add_dependency 'simplecov', '~> 0.9'
-  spec.add_dependency 'foodcritic', '~> 7.0'
+  spec.add_dependency 'foodcritic', '~> 8.0'
 
   # Integration gems
   # https://github.com/test-kitchen/test-kitchen/issues/922


### PR DESCRIPTION
This should bump foodcritic to 8.0.0 and allow us to drop the pin on 7.1 in chef-sk
